### PR TITLE
workaround for dplyr 1.0.8

### DIFF
--- a/R/plot_onedim.R
+++ b/R/plot_onedim.R
@@ -230,10 +230,9 @@ plot_onedim <- dynutils::inherit_default_params(
 
 #' @importFrom dplyr near
 make_connection_plotdata <- function(linearised) {
-  connections <- crossing(
-    linearised$milestone_network %>% select(.data$from, x_from = .data$cumstart),
-    linearised$milestone_network %>% select(.data$to, x_to = .data$cumend)
-  ) %>%
+  from <- linearised$milestone_network %>% select(.data$from, x_from = .data$cumstart)
+  to <- linearised$milestone_network %>% select(.data$to, x_to = .data$cumend)
+  connections <- crossing(from, to) %>%
     filter(
       .data$from == .data$to,
       .data$x_from != .data$x_to


### PR DESCRIPTION
As we try to get `dplyr` 1.0.8 ready for release, we stumbled upon this problem in `tidyr` : https://github.com/tidyverse/tidyr/issues/1221 that causes this failure: 

````
── After ─────────────────────────────────────────────────────────────────────────────────────────────────────
> checking examples ... ERROR
  Running examples in ‘dynplot-Ex.R’ failed
  The error most likely occurred in:
  
  > ### Name: plot_heatmap
  > ### Title: Plot expression data along a trajectory
  > ### Aliases: plot_heatmap
  > ### Keywords: plot_trajectory
  > 
  > ### ** Examples
  > 
  > data(example_bifurcating)
  > plot_heatmap(example_bifurcating)
  No features of interest provided, selecting the top 20 features automatically
  Using dynfeature for selecting the top 20 features
  Error:
    Column name `linearised$milestone_network %>% ...` must not be duplicated.
    Use .name_repair to specify repair.
  Caused by error in `stop_vctrs()`:
    Names must be unique.
    ✖ These names are duplicated:
      * "linearised$milestone_network %>% ..." at locations 1 and 2.
  Backtrace:
       ▆
    1. ├─dynplot::plot_heatmap(example_bifurcating)
    2. │ └─dynplot::plot_onedim(...)
    3. │   └─dynplot:::make_connection_plotdata(linearised)
    4. │     ├─... %>% ...
    5. │     └─tidyr::crossing(...)
    6. │       └─tidyr::expand_grid(!!!cols, .name_repair = .name_repair)
    7. │         ├─tibble::as_tibble(out, .name_repair = .name_repair)
    8. │         └─tibble:::as_tibble.list(out, .name_repair = .name_repair)
    9. │           └─tibble:::lst_to_tibble(x, .rows, .name_repair, col_lengths(x))
   10. │             └─tibble:::set_repaired_names(x, repair_hint = TRUE, .name_repair)
   11. │               ├─rlang::set_names(...)
   12. │               └─tibble:::repaired_names(...)
   13. │                 ├─tibble:::subclass_name_repair_errors(...)
   14. │                 │ └─base::withCallingHandlers(...)
   15. │                 └─vctrs::vec_as_names(...)
   16. │                   └─vctrs `<fn>`()
   17. │                     └─vctrs:::validate_unique(names = names, arg = arg)
   18. │                       └─vctrs:::stop_names_must_be_unique(names, arg)
   19. │                         └─vctrs:::stop_names(...)
   20. │                           └─vctrs:::stop_vctrs(class = c(class, "vctrs_error_names"), ...)
   21. ├─dplyr::mutate(., level = NA, direct = near(.data$x_diff, linearised$margin))
   22. ├─dplyr::arrange(., .data$x_diff)
   23. ├─dplyr::mutate(., x_diff = abs(.data$x_to - .data$x_from))
   24. └─dplyr::filter(., .data$from == .data$to, .data$x_from != .data$x_to)
  Execution halted

1 error x | 0 warnings ✓ | 0 notes ✓
````

This pull request is a workaround for this package to pass, until the `tidyr` issue is fixed. 
